### PR TITLE
[고도화] 민감 정보의 환경변수 치환 후 테스트 실패 현상 수정

### DIFF
--- a/project-board/src/main/resources/application.yaml
+++ b/project-board/src/main/resources/application.yaml
@@ -95,3 +95,9 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id # username 식별자를 id 로 하겠다
+
+---
+
+spring:
+  config.activate.on-profile: test
+  datasource.url: jdbc:h2:mem:testdb

--- a/project-board/src/test/java/com/study/projectboard/ProjectBoardApplicationTests.java
+++ b/project-board/src/test/java/com/study/projectboard/ProjectBoardApplicationTests.java
@@ -2,7 +2,9 @@ package com.study.projectboard;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ProjectBoardApplicationTests {
 


### PR DESCRIPTION
환경변수를 이용해 application.yaml 안에 있던 민감 정보를 치환하여 보안성을 높였으나
일부 스프링 부트 테스트가 실패한다.

@SpringBootTest는 초기 테스트 환경을 구성하면서 프로퍼티 파일의 설정을 참고하기 때문에
환경변수가 주입되지 않은 테스트 환경에서 의도하지 않은 동작을 보이며 실패할 수 있다.
이를 수정하여 테스트가 실패하지 않도록 하자.

<h1> Reference </h1>
* #67 